### PR TITLE
Feature/mediatr core

### DIFF
--- a/MinDiator.Tests/Handlers/Base/NotificationHandlerWrapperTests.cs
+++ b/MinDiator.Tests/Handlers/Base/NotificationHandlerWrapperTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Handlers.Base;
+using MinDiator.Interfaces;
+using Moq;
+
+namespace MinDiator.Tests.Handlers.Base
+{
+    public class NotificationHandlerWrapperTests
+    {
+        public class SampleNotification : INotification { }
+
+        [Fact]
+        public async Task Handle_ShouldInvokeAllRegisteredHandlers()
+        {
+            // Arrange
+            var mockHandler1 = new Mock<INotificationHandler<SampleNotification>>();
+            var mockHandler2 = new Mock<INotificationHandler<SampleNotification>>();
+
+            var services = new ServiceCollection()
+                .AddSingleton(mockHandler1.Object)
+                .AddSingleton(mockHandler2.Object)
+                .BuildServiceProvider();
+
+            var wrapper = new StaticCachedNotificationHandlerWrapper<SampleNotification>();
+            var notification = new SampleNotification();
+
+            // Act
+            await wrapper.Handle(notification, services, CancellationToken.None);
+
+            // Assert
+            mockHandler1.Verify(h => h.Handle(notification, CancellationToken.None), Times.Once);
+            mockHandler2.Verify(h => h.Handle(notification, CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldNotFailWhenNoHandlersRegistered()
+        {
+            // Arrange
+            var services = new ServiceCollection().BuildServiceProvider();
+            var wrapper = new StaticCachedNotificationHandlerWrapper<SampleNotification>();
+
+            // Act & Assert
+            await wrapper.Handle(new SampleNotification(), services, CancellationToken.None);
+        }
+    }
+}

--- a/MinDiator.Tests/Handlers/Base/RequestHandlerWrapperTests.cs
+++ b/MinDiator.Tests/Handlers/Base/RequestHandlerWrapperTests.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Configuration;
+using MinDiator.Handlers;
+using MinDiator.Handlers.Base;
+using MinDiator.Interfaces;
+using Moq;
+
+namespace MinDiator.Tests.Handlers.Base
+{
+    public class RequestHandlerWrapperTests
+    {
+        public class SampleRequest : IRequest<string> { }
+
+        [Fact]
+        public async Task Handle_ShouldReturnResponseWithoutBehaviors()
+        {
+            // Arrange
+            var expectedResponse = "response";
+            var mockHandler = new Mock<IRequestHandler<SampleRequest, string>>();
+            mockHandler.Setup(h => h.Handle(It.IsAny<SampleRequest>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(expectedResponse);
+
+            var services = new ServiceCollection()
+                .AddSingleton(mockHandler.Object)
+                .BuildServiceProvider();
+
+            var wrapper = new StaticCachedHandlerWrapper<SampleRequest, string>();
+            var request = new SampleRequest();
+
+            // Act
+            var result = await wrapper.Handle(request, services, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedResponse, result);
+        }
+
+        public class OrderedBehaviorBase : IPipelineBehavior<SampleRequest, string>
+        {
+            private readonly string _id;
+            private readonly Action<string> _execution;
+
+            protected OrderedBehaviorBase(string id, Action<string> execution)
+            {
+                _id = id;
+                _execution = execution;
+            }
+
+            public Task<string> Handle(SampleRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+            {
+                _execution(_id + ">");
+                return next(cancellationToken).ContinueWith(t =>
+                {
+                    _execution("<" + _id);
+                    return t.Result;
+                });
+            }
+        }
+
+        [PipelineOrder(2)]
+        public class Behavior2 : OrderedBehaviorBase
+        {
+            public Behavior2(Action<string> execution) : base("B2", execution) { }
+        }
+
+        [PipelineOrder(1)]
+        public class Behavior1 : OrderedBehaviorBase
+        {
+            public Behavior1(Action<string> execution) : base("B1", execution) { }
+        }
+
+        [Fact]
+        public async Task Handle_ShouldUsePipelineBehaviorsInOrder()
+        {
+            // Arrange
+            var executionLog = "";
+
+            var mockHandler = new Moq.Mock<IRequestHandler<SampleRequest, string>>();
+            mockHandler.Setup(h => h.Handle(It.IsAny<SampleRequest>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(() =>
+                       {
+                           executionLog += "H";
+                           return "done";
+                       });
+
+            var services = new ServiceCollection()
+                .AddSingleton<IRequestHandler<SampleRequest, string>>(mockHandler.Object)
+                .AddSingleton<IPipelineBehavior<SampleRequest, string>>(new Behavior2(s => executionLog += s))
+                .AddSingleton<IPipelineBehavior<SampleRequest, string>>(new Behavior1(s => executionLog += s))
+                .BuildServiceProvider();
+
+            var wrapper = new StaticCachedHandlerWrapper<SampleRequest, string>();
+            var request = new SampleRequest();
+
+            // Act
+            var result = await wrapper.Handle(request, services, CancellationToken.None);
+
+            // Assert
+            Assert.Equal("B1>B2>H<B2<B1", executionLog);
+            Assert.Equal("done", result);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrowWhenNoHandlerIsRegistered()
+        {
+            // Arrange
+            var services = new ServiceCollection().BuildServiceProvider();
+            var wrapper = new StaticCachedHandlerWrapper<SampleRequest, string>();
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                wrapper.Handle(new SampleRequest(), services, CancellationToken.None));
+
+            Assert.Contains("Handler of type", exception.Message);
+        }
+    }
+}

--- a/MinDiator.Tests/Handlers/MediatorTests.cs
+++ b/MinDiator.Tests/Handlers/MediatorTests.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Handlers;
+using MinDiator.Interfaces;
+using Moq;
+
+namespace MinDiator.Tests.Handlers
+{
+    public class MediatorTests
+    {
+        [Fact]
+        public async Task Send_Generic_WithValidRequest_CallsHandler()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+            var request = new TestRequest();
+
+            // Act
+            var response = await mediator.Send(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal("Test Response", response.Value);
+        }
+
+        [Fact]
+        public async Task Send_Object_WithValidRequest_CallsHandler()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+            object request = new TestRequest();
+
+            // Act
+            var response = await mediator.Send(request);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.IsType<TestResponse>(response);
+            Assert.Equal("Test Response", ((TestResponse)response).Value);
+        }
+
+        [Fact]
+        public async Task Send_Generic_WithCachedHandler_ReusesHandler()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+            var request = new TestRequest();
+
+            // Act
+            // Call twice to test caching
+            var response1 = await mediator.Send(request);
+            var response2 = await mediator.Send(request);
+
+            // Assert
+            Assert.NotNull(response1);
+            Assert.NotNull(response2);
+            Assert.Equal("Test Response", response1.Value);
+            Assert.Equal("Test Response", response2.Value);
+        }
+
+        [Fact]
+        public void Send_Generic_WithNullRequest_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(() => mediator.Send<TestResponse>(null));
+        }
+
+        [Fact]
+        public void Send_Object_WithNullRequest_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(() => mediator.Send(null));
+        }
+
+        [Fact]
+        public void Send_Object_WithInvalidRequest_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var serviceProvider = CreateServiceProviderWithHandler<TestRequest, TestResponse>();
+            var mediator = new Mediator(serviceProvider);
+            object request = new InvalidRequest(); // Doesn't implement IRequest<>
+
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(() => mediator.Send(request));
+        }
+
+        private IServiceProvider CreateServiceProviderWithHandler<TRequest, TResponse>()
+            where TRequest : IRequest<TResponse>
+        {
+            var services = new ServiceCollection();
+
+            // Register request handler
+            services.AddTransient<IRequestHandler<TRequest, TResponse>>(sp =>
+            {
+                var mock = new Mock<IRequestHandler<TRequest, TResponse>>();
+                mock.Setup(h => h.Handle(It.IsAny<TRequest>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Activator.CreateInstance<TResponse>());
+                return mock.Object;
+            });
+
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/MinDiator.Tests/Handlers/PublisherTests.cs
+++ b/MinDiator.Tests/Handlers/PublisherTests.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Handlers;
+using MinDiator.Interfaces;
+using Moq;
+
+namespace MinDiator.Tests.Handlers
+{
+    public class PublisherTests
+    {
+        [Fact]
+        public async Task Publish_Generic_WithValidNotification_CallsHandlers()
+        {
+            // Arrange
+            var mockHandler = new Mock<INotificationHandler<TestNotification>>();
+            mockHandler.Setup(h => h.Handle(It.IsAny<TestNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var serviceProvider = CreateServiceProviderWithNotificationHandler(mockHandler.Object);
+            var publisher = new Publisher(serviceProvider);
+            var notification = new TestNotification();
+
+            // Act
+            await publisher.Publish(notification);
+
+            // Assert
+            mockHandler.Verify(h => h.Handle(notification, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_Interface_WithValidNotification_CallsHandlers()
+        {
+            // Arrange
+            var mockHandler = new Mock<INotificationHandler<TestNotification>>();
+            mockHandler.Setup(h => h.Handle(It.IsAny<TestNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var serviceProvider = CreateServiceProviderWithNotificationHandler(mockHandler.Object);
+            var publisher = new Publisher(serviceProvider);
+            INotification notification = new TestNotification();
+
+            // Act
+            await publisher.Publish(notification);
+
+            // Assert
+            mockHandler.Verify(h => h.Handle(It.IsAny<TestNotification>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_WithMultipleHandlers_CallsAllHandlers()
+        {
+            // Arrange
+            var mockHandler1 = new Mock<INotificationHandler<TestNotification>>();
+            var mockHandler2 = new Mock<INotificationHandler<TestNotification>>();
+
+            mockHandler1.Setup(h => h.Handle(It.IsAny<TestNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            mockHandler2.Setup(h => h.Handle(It.IsAny<TestNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var services = new ServiceCollection();
+            services.AddTransient<INotificationHandler<TestNotification>>(sp => mockHandler1.Object);
+            services.AddTransient<INotificationHandler<TestNotification>>(sp => mockHandler2.Object);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var publisher = new Publisher(serviceProvider);
+            var notification = new TestNotification();
+
+            // Act
+            await publisher.Publish(notification);
+
+            // Assert
+            mockHandler1.Verify(h => h.Handle(notification, It.IsAny<CancellationToken>()), Times.Once);
+            mockHandler2.Verify(h => h.Handle(notification, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public void Publish_Generic_WithNullNotification_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var publisher = new Publisher(serviceProvider);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(() => publisher.Publish<TestNotification>(null));
+        }
+
+        [Fact]
+        public void Publish_Interface_WithNullNotification_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var publisher = new Publisher(serviceProvider);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(() => publisher.Publish(null));
+        }
+
+        [Fact]
+        public void Publish_Interface_WithInvalidNotification_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var publisher = new Publisher(serviceProvider);
+            INotification notification = new InvalidNotification();
+
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(() => publisher.Publish(notification));
+        }
+
+        private IServiceProvider CreateServiceProviderWithNotificationHandler<TNotification>(
+            INotificationHandler<TNotification> handler)
+            where TNotification : INotification
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<INotificationHandler<TNotification>>(sp => handler);
+            return services.BuildServiceProvider();
+        }
+    }    
+}

--- a/MinDiator.Tests/Handlers/SenderTests.cs
+++ b/MinDiator.Tests/Handlers/SenderTests.cs
@@ -1,0 +1,50 @@
+﻿using Moq;
+
+namespace MinDiator.Tests.Handlers
+{
+    public class SenderTests
+    {
+        [Fact]
+        public async Task Send_DelegatesCallToMediator()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            var request = new TestRequest();
+            var expectedResponse = new TestResponse { Value = "Test Response" };
+
+            mockMediator.Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResponse);
+
+            var sender = new Sender(mockMediator.Object);
+
+            // Act
+            var response = await sender.Send(request);
+
+            // Assert
+            Assert.Equal(expectedResponse, response);
+            mockMediator.Verify(m => m.Send(request, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Send_WithCancellationToken_DelegatesCallToMediator()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            var request = new TestRequest();
+            var expectedResponse = new TestResponse { Value = "Test Response" };
+            var cancellationToken = new CancellationToken();
+
+            mockMediator.Setup(m => m.Send(request, cancellationToken))
+                .ReturnsAsync(expectedResponse);
+
+            var sender = new Sender(mockMediator.Object);
+
+            // Act
+            var response = await sender.Send(request, cancellationToken);
+
+            // Assert
+            Assert.Equal(expectedResponse, response);
+            mockMediator.Verify(m => m.Send(request, cancellationToken), Times.Once);
+        }
+    }
+}

--- a/MinDiator.Tests/Handlers/TestData.cs
+++ b/MinDiator.Tests/Handlers/TestData.cs
@@ -1,0 +1,31 @@
+﻿using MinDiator.Interfaces;
+
+namespace MinDiator.Tests.Handlers
+{
+    #region Test Classes
+
+    public class TestRequest : IRequest<TestResponse>
+    {
+    }
+
+    public class TestResponse
+    {
+        public string Value { get; set; } = "Test Response";
+    }
+
+    public class InvalidRequest
+    {
+        // Doesn't implement IRequest<>
+    }
+
+    public class TestNotification : INotification
+    {
+    }
+
+    public class InvalidNotification : INotification
+    {
+        // Implementation that would cause issues in the real code
+    }
+
+    #endregion
+}

--- a/MinDiator.Tests/MinDiator.Tests.csproj
+++ b/MinDiator.Tests/MinDiator.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Nuget\MinDiator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/MinDiator.sln
+++ b/MinDiator.sln
@@ -3,13 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinDiator", "src\Nuget\MinDiator.csproj", "{E5BEE56E-338A-46FC-993B-7084E554370B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinDiator", "src\Nuget\MinDiator.csproj", "{E5BEE56E-338A-46FC-993B-7084E554370B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleMinimalAPI", "src\SampleMinimalAPI\SampleMinimalAPI.csproj", "{19E1E4AF-AD1E-46CD-9FFE-85C69C931187}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleMinimalAPI", "src\SampleMinimalAPI\SampleMinimalAPI.csproj", "{19E1E4AF-AD1E-46CD-9FFE-85C69C931187}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleAPI", "src\SampleAPI\SampleAPI.csproj", "{835E3DDF-718E-498C-A723-2DCB89B30823}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAPI", "src\SampleAPI\SampleAPI.csproj", "{835E3DDF-718E-498C-A723-2DCB89B30823}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "src\Benchmark\Benchmark.csproj", "{B12C1399-5D1B-4B09-8827-33DCE84F6B56}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "src\Benchmark\Benchmark.csproj", "{B12C1399-5D1B-4B09-8827-33DCE84F6B56}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{55174B9C-9A11-4234-880C-A0758DDB2365}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B11D9266-55D6-4B33-BD9B-2B3F5261950F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinDiator.Tests", "MinDiator.Tests\MinDiator.Tests.csproj", "{A8E3CB7D-0374-4396-821B-E68C385882C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,8 +39,22 @@ Global
 		{B12C1399-5D1B-4B09-8827-33DCE84F6B56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B12C1399-5D1B-4B09-8827-33DCE84F6B56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B12C1399-5D1B-4B09-8827-33DCE84F6B56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8E3CB7D-0374-4396-821B-E68C385882C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8E3CB7D-0374-4396-821B-E68C385882C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8E3CB7D-0374-4396-821B-E68C385882C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8E3CB7D-0374-4396-821B-E68C385882C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E5BEE56E-338A-46FC-993B-7084E554370B} = {55174B9C-9A11-4234-880C-A0758DDB2365}
+		{19E1E4AF-AD1E-46CD-9FFE-85C69C931187} = {55174B9C-9A11-4234-880C-A0758DDB2365}
+		{835E3DDF-718E-498C-A723-2DCB89B30823} = {55174B9C-9A11-4234-880C-A0758DDB2365}
+		{B12C1399-5D1B-4B09-8827-33DCE84F6B56} = {55174B9C-9A11-4234-880C-A0758DDB2365}
+		{A8E3CB7D-0374-4396-821B-E68C385882C1} = {B11D9266-55D6-4B33-BD9B-2B3F5261950F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6CD9D5E-5987-415D-9979-4EA6B8A54B34}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ public class MinDiatorPerformanceBehavior<TRequest, TResponse> : IPipelineBehavi
 ## ✅ Roadmap
 
 - [x] Pipeline Behaviors
-- [x] Exception Handlers
+- [] Exception Handlers
+- [x] IPublisher and INotification
 - [x] Test helpers
 
 ---

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Benchmark/Benchmarks.cs
+++ b/src/Benchmark/Benchmarks.cs
@@ -7,12 +7,17 @@ public class Benchmarks
 {
     private MediatR.ISender _senderMediatR;
     private MediatR.IMediator _mediatR;
+    private MediatR.IPublisher _publisherMediatR;
 
     private MinDiator.ISender _senderMinDiator;
     private MinDiator.IMediator _minDiator;
+    private MinDiator.Interfaces.IPublisher _publisherMinDiator;
 
     private MediatR.IRequest<string> _requestMediatR = new SampleRequest();
     private MinDiator.Interfaces.IRequest<string> _requestMinDiator = new SampleRequest();
+
+    private MediatR.INotification _notificationMediatR = new SampleNotification();
+    private MinDiator.Interfaces.INotification _notificationMinDiator = new SampleNotification();
 
     [GlobalSetup]
     public void Setup()
@@ -39,6 +44,9 @@ public class Benchmarks
 
         _senderMediatR = provider.GetRequiredService<MediatR.ISender>();
         _senderMinDiator = provider.GetRequiredService<MinDiator.ISender>();
+
+        _publisherMediatR = provider.GetRequiredService<MediatR.IPublisher>();
+        _publisherMinDiator = provider.GetRequiredService<MinDiator.Interfaces.IPublisher>();
     }
 
     [Benchmark]
@@ -53,17 +61,29 @@ public class Benchmarks
         return await _minDiator.Send(_requestMinDiator);
     }
 
-    [Benchmark]
-    public async Task<string> MediatR_ISender_Send()
-    {
-        return await _senderMediatR.Send(_requestMediatR);
-    }
+    //[Benchmark]
+    //public async Task<string> MediatR_ISender_Send()
+    //{
+    //    return await _senderMediatR.Send(_requestMediatR);
+    //}
 
-    [Benchmark]
-    public async Task<string> MinDiator_ISender_Send()
-    {
-        return await _senderMinDiator.Send(_requestMinDiator);
-    }
+    //[Benchmark]
+    //public async Task<string> MinDiator_ISender_Send()
+    //{
+    //    return await _senderMinDiator.Send(_requestMinDiator);
+    //}
+
+    //[Benchmark]
+    //public async Task MediatR_IPublisher_Publish()
+    //{
+    //    await _publisherMediatR.Publish(_notificationMediatR);
+    //}
+
+    //[Benchmark]
+    //public async Task MinDiator_IPublisher_Publish()
+    //{
+    //    await _publisherMinDiator.Publish(_notificationMinDiator);
+    //}
 }
 
 // Sample request/handler for both
@@ -76,5 +96,28 @@ public class SampleHandler : MinDiator.Interfaces.IRequestHandler<SampleRequest,
     public Task<string> Handle(SampleRequest request, CancellationToken cancellationToken = default)
     {
         return Task.FromResult("ok");
+    }
+}
+
+// Sample notification/handlers for both
+public class SampleNotification : MinDiator.Interfaces.INotification, MediatR.INotification
+{
+}
+
+public class SampleNotificationHandler1 : MinDiator.Interfaces.INotificationHandler<SampleNotification>, MediatR.INotificationHandler<SampleNotification>
+{
+    public Task Handle(SampleNotification notification, CancellationToken cancellationToken)
+    {
+        // Just a simple handler that does nothing
+        return Task.CompletedTask;
+    }
+}
+
+public class SampleNotificationHandler2 : MinDiator.Interfaces.INotificationHandler<SampleNotification>, MediatR.INotificationHandler<SampleNotification>
+{
+    public Task Handle(SampleNotification notification, CancellationToken cancellationToken)
+    {
+        // Second handler to test multiple handlers scenario
+        return Task.CompletedTask;
     }
 }

--- a/src/Benchmark/Benchmarks.cs
+++ b/src/Benchmark/Benchmarks.cs
@@ -61,29 +61,29 @@ public class Benchmarks
         return await _minDiator.Send(_requestMinDiator);
     }
 
-    //[Benchmark]
-    //public async Task<string> MediatR_ISender_Send()
-    //{
-    //    return await _senderMediatR.Send(_requestMediatR);
-    //}
+    [Benchmark]
+    public async Task<string> MediatR_ISender_Send()
+    {
+        return await _senderMediatR.Send(_requestMediatR);
+    }
 
-    //[Benchmark]
-    //public async Task<string> MinDiator_ISender_Send()
-    //{
-    //    return await _senderMinDiator.Send(_requestMinDiator);
-    //}
+    [Benchmark]
+    public async Task<string> MinDiator_ISender_Send()
+    {
+        return await _senderMinDiator.Send(_requestMinDiator);
+    }
 
-    //[Benchmark]
-    //public async Task MediatR_IPublisher_Publish()
-    //{
-    //    await _publisherMediatR.Publish(_notificationMediatR);
-    //}
+    [Benchmark]
+    public async Task MediatR_IPublisher_Publish()
+    {
+        await _publisherMediatR.Publish(_notificationMediatR);
+    }
 
-    //[Benchmark]
-    //public async Task MinDiator_IPublisher_Publish()
-    //{
-    //    await _publisherMinDiator.Publish(_notificationMinDiator);
-    //}
+    [Benchmark]
+    public async Task MinDiator_IPublisher_Publish()
+    {
+        await _publisherMinDiator.Publish(_notificationMinDiator);
+    }
 }
 
 // Sample request/handler for both

--- a/src/Benchmark/MediatRPerformanceBehavior.cs
+++ b/src/Benchmark/MediatRPerformanceBehavior.cs
@@ -12,7 +12,8 @@ public class MediatRPerformanceBehavior<TRequest, TResponse> : IPipelineBehavior
         var response = await next();
         stopwatch.Stop();
 
-        Console.WriteLine($"[MediatR] {typeof(TRequest).Name} executed in {stopwatch.ElapsedMilliseconds}ms");
+        // Here we can do anything with the elapsed time, like logging it.
+
         return response;
     }
 }

--- a/src/Benchmark/MinDiatorPerformanceBehavior.cs
+++ b/src/Benchmark/MinDiatorPerformanceBehavior.cs
@@ -11,9 +11,9 @@ public class MinDiatorPerformanceBehavior<TRequest, TResponse> : MinDiator.Inter
         var stopwatch = Stopwatch.StartNew();
         var response = await next();
         stopwatch.Stop();
-        var requestName = request.GetType().Name;
 
-        Console.WriteLine($"[MinDiator] {requestName} executed in {stopwatch.ElapsedMilliseconds}ms");
+        // Here we can do anything with the elapsed time, like logging it.
+
         return response;
     }
 }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -7,10 +7,6 @@ public static class Program
     public static void Main(string[] args)
     {
         BenchmarkRunner.Run<Benchmarks>();
-        //var b = new Benchmarks();
-        //b.Setup();
-        //Console.WriteLine(b.MinDiator_IMediator_Send().GetAwaiter().GetResult());
-        //b.MinDiator_IPublisher_Publish().GetAwaiter().GetResult();
     }
 }
 

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -7,6 +7,10 @@ public static class Program
     public static void Main(string[] args)
     {
         BenchmarkRunner.Run<Benchmarks>();
+        //var b = new Benchmarks();
+        //b.Setup();
+        //Console.WriteLine(b.MinDiator_IMediator_Send().GetAwaiter().GetResult());
+        //b.MinDiator_IPublisher_Publish().GetAwaiter().GetResult();
     }
 }
 

--- a/src/Nuget/Configuration/MinDiatorConfiguration.cs
+++ b/src/Nuget/Configuration/MinDiatorConfiguration.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Handlers;
 using MinDiator.Interfaces;
 using System.Reflection;
 
 namespace MinDiator.Configuration;
 
 /// <summary>
-/// Classe de configuração para registrar serviços do padrão Mediator no container de DI
+/// Configuration class for registering Mediator pattern services in the DI container.
 /// </summary>
 public class MinDiatorConfiguration
 {
@@ -16,23 +17,23 @@ public class MinDiatorConfiguration
     private bool _hasRegistered = false;
 
     /// <summary>
-    /// Construtor interno usado pela extensão AddMediatorPattern
+    /// Internal constructor used by the AddMediatorPattern extension.
     /// </summary>
-    /// <param name="services">Coleção de serviços do DI</param>
+    /// <param name="services">DI service collection.</param>
     internal MinDiatorConfiguration(IServiceCollection services)
     {
-        _services = services ?? throw new ArgumentNullException(nameof(services), "IServiceCollection não pode ser nulo.");
+        _services = services ?? throw new ArgumentNullException(nameof(services), "IServiceCollection cannot be null.");
     }
 
     /// <summary>
-    /// Registra handlers e behaviors de um assembly específico
+    /// Registers handlers and behaviors from a specific assembly.
     /// </summary>
-    /// <param name="assembly">Assembly a ser escaneado</param>
-    /// <returns>A instância de configuração para chamadas em cadeia</returns>
+    /// <param name="assembly">Assembly to be scanned.</param>
+    /// <returns>The configuration instance for method chaining.</returns>
     public MinDiatorConfiguration RegisterServicesFromAssembly(Assembly assembly)
     {
         if (assembly == null)
-            throw new ArgumentNullException(nameof(assembly), "Assembly fornecido não pode ser nulo.");
+            throw new ArgumentNullException(nameof(assembly), "Provided assembly cannot be null.");
 
         if (!_assemblies.Contains(assembly))
             _assemblies.Add(assembly);
@@ -40,30 +41,28 @@ public class MinDiatorConfiguration
         return this;
     }
 
-
     /// <summary>
-    /// Registra handlers e behaviors do assembly que contém o tipo especificado
+    /// Registers handlers and behaviors from the assembly that contains the specified type.
     /// </summary>
-    /// <typeparam name="T">Tipo cujo assembly será escaneado</typeparam>
-    /// <returns>A instância de configuração para chamadas em cadeia</returns>
+    /// <typeparam name="T">Type whose assembly will be scanned.</typeparam>
+    /// <returns>The configuration instance for method chaining.</returns>
     public MinDiatorConfiguration RegisterServicesFromAssemblyContaining<T>()
     {
         var assembly = typeof(T).Assembly;
         return assembly == null
-            ? throw new InvalidOperationException($"Não foi possível localizar o assembly para o tipo {typeof(T).FullName}.")
+            ? throw new InvalidOperationException($"Could not locate the assembly for type {typeof(T).FullName}.")
             : RegisterServicesFromAssembly(assembly);
     }
 
-
     /// <summary>
-    /// Registra handlers e behaviors de múltiplos assemblies
+    /// Registers handlers and behaviors from multiple assemblies.
     /// </summary>
-    /// <param name="assemblies">Assemblies a serem escaneados</param>
-    /// <returns>A instância de configuração para chamadas em cadeia</returns>
+    /// <param name="assemblies">Assemblies to be scanned.</param>
+    /// <returns>The configuration instance for method chaining.</returns>
     public MinDiatorConfiguration RegisterServicesFromAssemblies(params Assembly[] assemblies)
     {
         if (assemblies == null || assemblies.Length == 0)
-            throw new ArgumentException("Ao menos um assembly deve ser fornecido.", nameof(assemblies));
+            throw new ArgumentException("At least one assembly must be provided.", nameof(assemblies));
 
         foreach (var assembly in assemblies)
         {
@@ -79,51 +78,50 @@ public class MinDiatorConfiguration
     }
 
     /// <summary>
-    /// Adiciona um behavior específico ao pipeline
+    /// Adds a specific behavior to the pipeline.
     /// </summary>
-    /// <param name="behaviorInterface">Tipo da interface do behavior</param>
-    /// <param name="behaviorImplementation">Tipo da implementação do behavior</param>
-    /// <param name="lifetime">Tempo de vida do serviço no container</param>
-    /// <returns>A instância de configuração para chamadas em cadeia</returns>
+    /// <param name="behaviorInterface">Type of the behavior interface.</param>
+    /// <param name="behaviorImplementation">Type of the behavior implementation.</param>
+    /// <param name="lifetime">Lifetime of the service in the container.</param>
+    /// <returns>The configuration instance for method chaining.</returns>
     public MinDiatorConfiguration AddBehavior(Type behaviorInterface, Type behaviorImplementation, ServiceLifetime lifetime = ServiceLifetime.Transient)
     {
         if (behaviorInterface == null)
-            throw new ArgumentNullException(nameof(behaviorInterface), "Interface do behavior não pode ser nula.");
+            throw new ArgumentNullException(nameof(behaviorInterface), "Behavior interface cannot be null.");
 
         if (behaviorImplementation == null)
-            throw new ArgumentNullException(nameof(behaviorImplementation), "Implementação do behavior não pode ser nula.");
+            throw new ArgumentNullException(nameof(behaviorImplementation), "Behavior implementation cannot be null.");
 
         _behaviors.Add((behaviorInterface, behaviorImplementation, lifetime));
         return this;
     }
 
     /// <summary>
-    /// Adiciona um handler de exceção específico
+    /// Adds a specific exception handler.
     /// </summary>
-    /// <param name="handlerInterface">Tipo da interface do handler de exceção</param>
-    /// <param name="handlerImplementation">Tipo da implementação do handler de exceção</param>
-    /// <returns>A instância de configuração para chamadas em cadeia</returns>
+    /// <param name="handlerInterface">Type of the exception handler interface.</param>
+    /// <param name="handlerImplementation">Type of the exception handler implementation.</param>
+    /// <returns>The configuration instance for method chaining.</returns>
     public MinDiatorConfiguration AddExceptionHandler(Type handlerInterface, Type handlerImplementation, ServiceLifetime lifetime = ServiceLifetime.Transient)
     {
         if (handlerInterface == null)
-            throw new ArgumentNullException(nameof(handlerInterface), "Interface do exception handler não pode ser nula.");
+            throw new ArgumentNullException(nameof(handlerInterface), "Exception handler interface cannot be null.");
 
         if (handlerImplementation == null)
-            throw new ArgumentNullException(nameof(handlerImplementation), "Implementação do exception handler não pode ser nula.");
+            throw new ArgumentNullException(nameof(handlerImplementation), "Exception handler implementation cannot be null.");
 
         _exceptionHandlers.Add((handlerInterface, handlerImplementation, lifetime));
         return this;
     }
 
     /// <summary>
-    /// Registra todos os serviços configurados no container de DI
-    /// Método interno chamado pela extensão AddMediatorPattern
+    /// Registers all configured services in the DI container.
+    /// Internal method called by the AddMediatorPattern extension.
     /// </summary>
     internal void Register()
     {
         if (!_assemblies.Any())
-            throw new InvalidOperationException("Nenhum assembly registrado. Utilize 'RegisterServicesFromAssembly' ou métodos similares para adicionar assemblies antes de registrar.");
-
+            throw new InvalidOperationException("No assemblies registered. Use 'RegisterServicesFromAssembly' or similar methods to add assemblies before registering.");
 
         foreach (var assembly in _assemblies.Distinct())
         {
@@ -137,28 +135,23 @@ public class MinDiatorConfiguration
             RegisterGenericHandlers(types, typeof(IRequestExceptionHandler<,,>));
         }
 
-        // Registrar behaviors configurados explicitamente
+        // Register explicitly configured behaviors.
         RegisterConfiguredBehaviors();
 
-        // Registrar exception handlers configurados explicitamente
+        // Register explicitly configured exception handlers.
         RegisterConfiguredExceptionHandlers();
 
-        //// Registrar o mediador
-        _services.AddScoped<IMediator>(provider =>
-        {
-            // Instancia a classe concreta
-            return new Mediator(provider, _assemblies);
-        });
-
-        _services.AddScoped<ISender, Sender>();
+        // Register the mediator.
+        _services.AddSingleton<IMediator, Mediator>();
+        _services.AddSingleton<ISender, Sender>();
 
         _hasRegistered = true;
     }
 
     /// <summary>
-    /// Registra handlers de requisições de um assembly específico
+    /// Registers request handlers from a specific assembly.
     /// </summary>
-    /// <param name="assembly">Assembly a ser escaneado</param>
+    /// <param name="assembly">Assembly to be scanned.</param>
     private void RegisterGenericHandlers(Type[] types, Type interfaceDefinition, ServiceLifetime lifetime = ServiceLifetime.Transient, bool skipOpenGenericImplementations = false)
     {
         foreach (var type in types)
@@ -177,7 +170,7 @@ public class MinDiatorConfiguration
     }
 
     /// <summary>
-    /// Registra behaviors configurados explicitamente
+    /// Registers explicitly configured behaviors.
     /// </summary>
     private void RegisterConfiguredBehaviors()
     {
@@ -188,13 +181,13 @@ public class MinDiatorConfiguration
     }
 
     /// <summary>
-    /// Registra handlers de exceção configurados explicitamente
+    /// Registers explicitly configured exception handlers.
     /// </summary>
     private void RegisterConfiguredExceptionHandlers()
     {
         foreach (var (interfaceType, implementationType, lifetime) in _exceptionHandlers)
         {
-            _services.Add(new ServiceDescriptor(interfaceType, implementationType));
+            _services.Add(new ServiceDescriptor(interfaceType, implementationType, lifetime));
         }
     }
 }

--- a/src/Nuget/Configuration/MinDiatorConfiguration.cs
+++ b/src/Nuget/Configuration/MinDiatorConfiguration.cs
@@ -133,6 +133,9 @@ public class MinDiatorConfiguration
             RegisterGenericHandlers(types, typeof(IRequestHandler<,>));
             RegisterGenericHandlers(types, typeof(IRequestExceptionHandler<,>));
             RegisterGenericHandlers(types, typeof(IRequestExceptionHandler<,,>));
+
+            // Adiciona registro para notification handlers
+            RegisterGenericHandlers(types, typeof(INotificationHandler<>));
         }
 
         // Register explicitly configured behaviors.
@@ -141,7 +144,8 @@ public class MinDiatorConfiguration
         // Register explicitly configured exception handlers.
         RegisterConfiguredExceptionHandlers();
 
-        // Register the mediator.
+        // Register the mediator components.
+        _services.AddSingleton<IPublisher, Publisher>();
         _services.AddSingleton<IMediator, Mediator>();
         _services.AddSingleton<ISender, Sender>();
 

--- a/src/Nuget/Handlers/Base/NotificationHandlerWrapper.cs
+++ b/src/Nuget/Handlers/Base/NotificationHandlerWrapper.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Interfaces;
+
+namespace MinDiator.Handlers.Base
+{
+    /// <summary>
+    /// Base class for notification handlers
+    /// </summary>
+    public abstract class NotificationHandlerBase
+    {
+        /// <summary>
+        /// Handles the notification with the appropriate handler
+        /// </summary>
+        /// <param name="notification">The notification to be handled</param>
+        /// <param name="serviceProvider">The service provider for resolving handlers</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the notification handling</returns>
+        public abstract Task Handle(object notification, IServiceProvider serviceProvider, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Wrapper for notification handlers that handles resolving and executing handlers
+    /// </summary>
+    /// <typeparam name="TNotification">The notification type</typeparam>
+    public abstract class NotificationHandlerWrapper<TNotification> : NotificationHandlerBase
+        where TNotification : INotification
+    {
+        /// <summary>
+        /// Handles the notification with all registered handlers
+        /// </summary>
+        /// <param name="notification">The notification to be handled</param>
+        /// <param name="serviceProvider">The service provider for resolving handlers</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the notification handling</returns>
+        public override Task Handle(object notification, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            return Handle((TNotification)notification, serviceProvider, cancellationToken);
+        }
+
+        /// <summary>
+        /// Handles the notification with all registered handlers
+        /// </summary>
+        /// <param name="notification">The notification to be handled</param>
+        /// <param name="serviceProvider">The service provider for resolving handlers</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the notification handling</returns>
+        public abstract Task Handle(TNotification notification, IServiceProvider serviceProvider, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Static cached wrapper for notification handlers to improve performance
+    /// </summary>
+    /// <typeparam name="TNotification">The notification type</typeparam>
+    public class StaticCachedNotificationHandlerWrapper<TNotification> : NotificationHandlerWrapper<TNotification>
+        where TNotification : INotification
+    {
+        private static readonly Type _handlerType = typeof(INotificationHandler<TNotification>);
+
+        /// <summary>
+        /// Handles the notification with all registered handlers
+        /// </summary>
+        /// <param name="notification">The notification to be handled</param>
+        /// <param name="serviceProvider">The service provider for resolving handlers</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the notification handling</returns>
+        public override async Task Handle(TNotification notification, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            // Usar GetServices em vez de GetService para obter todos os handlers
+            var handlers = serviceProvider.GetServices(typeof(INotificationHandler<TNotification>))
+                .Cast<INotificationHandler<TNotification>>()
+                .ToList();
+
+            if (handlers.Count == 0)
+            {
+                return; // Sem handlers para esta notificação
+            }
+
+            var tasks = new List<Task>();
+            foreach (var handler in handlers)
+            {
+                tasks.Add(handler.Handle(notification, cancellationToken));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Nuget/Handlers/Base/RequestHandlerWrapper.cs
+++ b/src/Nuget/Handlers/Base/RequestHandlerWrapper.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinDiator.Interfaces;
+
+namespace MinDiator.Handlers.Base
+{
+    /// <summary>
+    /// Base class to all request handlers.
+    /// </summary>
+    public abstract class RequestHandlerBase
+    {
+        /// <summary>
+        /// Handler method that will be called by the mediator.
+        /// </summary>
+        /// <param name="request">Request object.</param>
+        /// <param name="serviceProvider">Service provider.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task representing an operation that will return an object.</returns>
+        public abstract Task<object> Handle(object request, IServiceProvider serviceProvider,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Wrapper for request handlers, used to define a class with concrete type (which will be used for caching).
+    /// </summary>
+    /// <typeparam name="TResponse">Response type for this handler.</typeparam>
+    public abstract class RequestHandlerWrapper<TResponse> : RequestHandlerBase
+    {
+        /// <summary>
+        /// Handler method that will be called by the mediator.
+        /// </summary>
+        /// <param name="request">Request object.</param>
+        /// <param name="serviceProvider">Service provider.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task representing an operation that will return an object of type <typeparamref name="TResponse"/>.</returns>
+        public abstract Task<TResponse> Handle(IRequest<TResponse> request, IServiceProvider serviceProvider,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Implementation of a request handler wrapper that uses static caching for handler and behavior types.
+    /// </summary>
+    /// <typeparam name="TRequest">Request type.</typeparam>
+    /// <typeparam name="TResponse">Response type.</typeparam>
+    public class StaticCachedHandlerWrapper<TRequest, TResponse> : RequestHandlerWrapper<TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        // Cache for handler and behavior types, to avoid reflection on every request.
+        private static readonly Type _handlerType = typeof(IRequestHandler<TRequest, TResponse>);
+        private static readonly Type _behaviorType = typeof(IPipelineBehavior<TRequest, TResponse>);
+
+        /// <inheritdoc/>
+        public override async Task<object> Handle(object request, IServiceProvider serviceProvider,
+            CancellationToken cancellationToken)
+        {
+            return await Handle((IRequest<TResponse>)request, serviceProvider, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<TResponse> Handle(IRequest<TResponse> request, IServiceProvider serviceProvider,
+            CancellationToken cancellationToken)
+        {
+            // Get handler from the current scope.
+            var handler = (IRequestHandler<TRequest, TResponse>)serviceProvider.GetService(_handlerType);
+            if (handler == null)
+            {
+                throw new InvalidOperationException(
+                    $"Handler of type {_handlerType.Name} not found for request {typeof(TRequest).Name}");
+            }
+
+            // Create the base handler delegate.
+            RequestHandlerDelegate<TResponse> pipeline = (ct) => handler.Handle((TRequest)request, ct);
+
+            // Get behaviors from the current scope (respecting lifetimes).
+            var behaviors = serviceProvider.GetServices(_behaviorType)
+                .Cast<IPipelineBehavior<TRequest, TResponse>>()
+                .ToArray();
+
+            if (behaviors.Length == 0)
+            {
+                // No behaviors, execute handler directly.
+                return pipeline(cancellationToken);
+            }
+
+            // Build the pipeline (in reverse order).
+            for (int i = behaviors.Length - 1; i >= 0; i--)
+            {
+                var behavior = behaviors[i];
+                var next = pipeline;
+                pipeline = (ct) => behavior.Handle((TRequest)request, next, ct);
+            }
+
+            return pipeline(cancellationToken);
+        }
+    }
+}

--- a/src/Nuget/Handlers/Mediator.cs
+++ b/src/Nuget/Handlers/Mediator.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 namespace MinDiator.Handlers
 {
     /// <summary>
-    /// Mediator implementation that handles requests and responses caching wrappers for reduced reflection.
+    /// Mediator implementation that handles requests, responses and notifications with caching wrappers for reduced reflection.
     /// </summary>
     public class Mediator : IMediator
     {
@@ -18,6 +18,11 @@ namespace MinDiator.Handlers
         /// Cache of request handlers.
         /// </summary>
         private static readonly ConcurrentDictionary<Type, RequestHandlerBase> _requestHandlers = new();
+
+        /// <summary>
+        /// Cache of notification handlers.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, NotificationHandlerBase> _notificationHandlers = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mediator"/> class.
@@ -91,6 +96,6 @@ namespace MinDiator.Handlers
             });
 
             return handler.Handle(request, _serviceProvider, cancellationToken);
-        }
+        }        
     }
 }

--- a/src/Nuget/Handlers/Mediator.cs
+++ b/src/Nuget/Handlers/Mediator.cs
@@ -59,6 +59,7 @@ namespace MinDiator.Handlers
                 return (RequestHandlerBase)wrapper;
             });
 
+            // TODO: If you want to put back the logic of IExceptionHandler, this is the point.
             return handler.Handle(request, _serviceProvider, cancellationToken);
         }
 
@@ -95,6 +96,7 @@ namespace MinDiator.Handlers
                 return (RequestHandlerBase)wrapper;
             });
 
+            // TODO: If you want to put back the logic of IExceptionHandler, this is the point.
             return handler.Handle(request, _serviceProvider, cancellationToken);
         }        
     }

--- a/src/Nuget/Handlers/Mediator.cs
+++ b/src/Nuget/Handlers/Mediator.cs
@@ -1,327 +1,96 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using MinDiator.Configuration;
-using MinDiator.Entities;
-using MinDiator.Handlers;
+﻿using MinDiator.Handlers.Base;
 using MinDiator.Interfaces;
 using System.Collections.Concurrent;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.ExceptionServices;
 
-namespace MinDiator;
-
-/// <summary>
-/// Implementação principal do Mediator, responsável por enviar requisições aos handlers apropriados
-/// e coordenar a execução dos behaviors e tratamento de exceções
-/// </summary>
-public class Mediator : IMediator, ISender
+namespace MinDiator.Handlers
 {
-    private readonly IServiceProvider _serviceProvider;
-    private static readonly ConcurrentDictionary<Type, Type> _handlerTypeCache = new();
-    private static readonly ConcurrentDictionary<Type, Func<object, object, CancellationToken, Task<object>>> _handlerDelegates = new();
-    private static readonly ConcurrentDictionary<Type, (IReadOnlyList<object> Behaviors, Delegate HandleDelegate)> _pipelineCache = new();
-    private readonly Dictionary<string, IReadOnlyList<object>> _behaviorMap;
-
     /// <summary>
-    /// Construtor que recebe o provedor de serviços para resolução de handlers e behaviors
+    /// Mediator implementation that handles requests and responses caching wrappers for reduced reflection.
     /// </summary>
-    /// <param name="serviceProvider"></param>
-    /// <param name="assemblies"></param>
-    public Mediator(IServiceProvider serviceProvider, List<Assembly> assemblies)
+    public class Mediator : IMediator
     {
-        _serviceProvider = serviceProvider;
-        _behaviorMap = new Dictionary<string, IReadOnlyList<object>>();
+        /// <summary>
+        /// The service provider used to resolve dependencies.
+        /// </summary>
+        private readonly IServiceProvider _serviceProvider;
 
-        assemblies
-            .Where(a => !a.IsDynamic && !a.FullName.StartsWith("System"))
-            .SelectMany(a => a.GetTypes())
-            .Where(t =>
-                t.IsClass &&
-                !t.IsAbstract &&
-                t.GetInterfaces().Any(i =>
-                    i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>))
-            )
-            .ToList().ForEach(e =>
-            {
-                var responseType = GetResponseTypeFromRequest(e);
-                var requestType = e.GetInterfaces()
-                    .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>));
+        /// <summary>
+        /// Cache of request handlers.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, RequestHandlerBase> _requestHandlers = new();
 
-                var behaviorPipelineType = typeof(IPipelineBehavior<,>).MakeGenericType(requestType, responseType);
-
-                var instance = _serviceProvider.GetServices(behaviorPipelineType)
-                                        .OrderBy(b => b.GetType().GetCustomAttribute<PipelineOrderAttribute>()?.Order ?? int.MaxValue)
-                                        .ToList();
-
-                _behaviorMap[e.AssemblyQualifiedName] = instance;
-            });
-    }
-
-    /// <summary>
-    /// Getter para Response by Request
-    /// </summary>
-    /// <param name="requestType"></param>
-    /// <returns></returns>
-    private Type GetResponseTypeFromRequest(Type requestType)
-    {
-        var requestInterface = requestType
-            .GetInterfaces()
-            .FirstOrDefault(i =>
-                i.IsGenericType &&
-                i.GetGenericTypeDefinition() == typeof(IRequest<>));
-
-        return requestInterface?.GetGenericArguments()[0];
-    }
-
-    /// <summary>
-    /// Envia uma requisição fortemente tipada para o handler apropriado
-    /// </summary>
-    /// <typeparam name="TResponse">Tipo da resposta esperada</typeparam>
-    /// <param name="request">A requisição a ser processada</param>
-    /// <param name="cancellationToken">Token de cancelamento para operações assíncronas</param>
-    /// <returns>A resposta do handler</returns>
-    public async Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
-    {
-        var requestType = request.GetType();
-
-        try
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mediator"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider used to resolve dependencies.</param>
+        public Mediator(IServiceProvider serviceProvider)
         {
-            // Criar o pipeline com os behaviors e executar a requisição
-            return await CreateRequestPipeline<TResponse>(request, cancellationToken);
+            _serviceProvider = serviceProvider;
         }
-        catch (Exception ex)
+
+        /// <summary>
+        /// Sends a request and returns the response of type TResponse.
+        /// </summary>
+        /// <typeparam name="TResponse">The type of the response.</typeparam>
+        /// <param name="request">The request to be sent.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The response of type TResponse, wrapped into a Task.</returns>
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
         {
-            // Lidar com a exceção usando IRequestExceptionHandler, se disponível
-            var actualException = ex.InnerException ?? ex;
-            var exceptionType = actualException.GetType();
-            var responseType = typeof(TResponse);
-
-            // Tentar encontrar os handlers de exceção específicos para este request e tipo de exceção
-            var exceptionHandlerType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(requestType, responseType, exceptionType);
-            var exceptionHandlers = _serviceProvider.GetServices(exceptionHandlerType).ToList();
-
-            if (exceptionHandlers.Any())
+            if (request == null)
             {
-                var exceptionHandlerState = new RequestExceptionHandlerState<TResponse>();
-
-                // Tentar cada handler de exceção registrado até que um deles trate a exceção
-                foreach (var exceptionHandler in exceptionHandlers)
-                {
-                    var handleMethod = exceptionHandlerType.GetMethod("Handle");
-                    var handleTask = (Task<Unit>)handleMethod.Invoke(exceptionHandler, new object[] { request, actualException, exceptionHandlerState, cancellationToken });
-                    await handleTask;
-
-                    // Se o handler tratou a exceção, retornar a resposta fornecida
-                    if (exceptionHandlerState.Handled)
-                    {
-                        return exceptionHandlerState.Response;
-                    }
-                }
+                throw new ArgumentNullException(nameof(request));
             }
 
-            // Se nenhum handler de exceção tratou, relançar a exceção
-            throw;
-        }
-    }
+            var requestType = request.GetType();
+            var handler = (RequestHandlerWrapper<TResponse>)_requestHandlers.GetOrAdd(requestType, type =>
+            {
+                var responseType = typeof(TResponse);
+                var wrapperType = typeof(StaticCachedHandlerWrapper<,>).MakeGenericType(type, responseType);
 
-    /// <summary>
-    /// Cria o pipeline de requisição com todos os behaviors registrados
-    /// </summary>
-    /// <typeparam name="TResponse">Tipo da resposta esperada</typeparam>
-    /// <param name="request">A requisição a ser processada</param>
-    /// <param name="cancellationToken">Token de cancelamento para operações assíncronas</param>
-    /// <returns>A resposta após a execução do pipeline</returns>
-    private async Task<TResponse> CreateRequestPipeline<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken)
-    {
-        var requestType = request.GetType();
-        var pipelineInfo = _pipelineCache.GetOrAdd(
-            requestType,
-            _ => BuildPipeline<TResponse>(requestType));
+                var wrapper = Activator.CreateInstance(wrapperType)
+                    ?? throw new InvalidOperationException($"Could not create wrapper type for {type}");
 
-        if (pipelineInfo.Behaviors.Count == 0)
-            return await ExecuteHandler(request, cancellationToken);
+                return (RequestHandlerBase)wrapper;
+            });
 
-        //Inicializa o pipeline com o handler final
-        RequestHandlerDelegate<TResponse> pipeline = () => ExecuteHandler(request, cancellationToken);
-
-        foreach (var behavior in pipelineInfo.Behaviors.Cast<dynamic>().Reverse())
-        {
-            var currentPipeline = pipeline;
-            pipeline = () => behavior.Handle((dynamic)request, currentPipeline, cancellationToken);
+            return handler.Handle(request, _serviceProvider, cancellationToken);
         }
 
-        return await pipeline();
-    }
-
-    private (IReadOnlyList<object> Behaviors, Delegate HandleDelegate) BuildPipeline<TResponse>(Type requestType)
-    {
-        return (_behaviorMap[requestType.AssemblyQualifiedName], null);
-        //var behaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(requestType, typeof(TResponse));
-        //var behaviors = _serviceProvider.GetServices(behaviorType)
-        //                                .OrderBy(b => b.GetType().GetCustomAttribute<PipelineOrderAttribute>()?.Order ?? int.MaxValue)
-        //                                .ToList();
-
-        //return (behaviors, null);
-    }
-
-    /// <summary>
-    /// Executa o handler apropriado para a requisição
-    /// </summary>
-    /// <typeparam name="TResponse">Tipo da resposta esperada</typeparam>
-    /// <param name="request">A requisição a ser processada</param>
-    /// <param name="cancellationToken">Token de cancelamento para operações assíncronas</param>
-    /// <returns>A resposta do handler</returns>
-    private async Task<TResponse> ExecuteHandler<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken)
-    {
-        var requestType = request.GetType();
-        var responseType = typeof(TResponse);
-
-        // Obter o handler
-        var handlerType = GetHandlerType(requestType);
-        var handler = GetHandler(_serviceProvider, handlerType);
-
-        if (handler == null)
+        /// <summary>
+        /// Sends a request and returns the response as an object.
+        /// </summary>
+        /// <param name="request">The request to be sent.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The response as an object, wrapped into a Task.</returns>
+        public Task<object> Send(object request, CancellationToken cancellationToken = default)
         {
-            throw new InvalidOperationException($"Não foi encontrado um handler para {requestType.Name}");
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var requestType = request.GetType();
+            var handler = _requestHandlers.GetOrAdd(requestType, type =>
+            {
+                var requestInterface = type.GetInterfaces()
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>));
+
+                if (requestInterface == null)
+                {
+                    throw new InvalidOperationException($"Request type {type.Name} does not implement IRequest<TResponse>");
+                }
+
+                var responseType = requestInterface.GetGenericArguments()[0];
+                var wrapperType = typeof(StaticCachedHandlerWrapper<,>).MakeGenericType(type, responseType);
+
+                var wrapper = Activator.CreateInstance(wrapperType)
+                    ?? throw new InvalidOperationException($"Could not create wrapper type for {type}");
+
+                return (RequestHandlerBase)wrapper;
+            });
+
+            return handler.Handle(request, _serviceProvider, cancellationToken);
         }
-
-        // Executar o handler
-        var handlerDelegate = GetHandlerDelegate(handler.GetType());
-        var result = await handlerDelegate(handler, request, cancellationToken);
-
-        return (TResponse)result;
-    }
-
-
-    private static Type GetHandlerType(Type requestType)
-    {
-        return _handlerTypeCache.GetOrAdd(requestType, static type =>
-        {
-            //Encontrar a interface
-            var requestInterface = type
-                                    .GetInterfaces()
-                                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>))
-                                    ?? throw new InvalidOperationException($"Tipo {type} não implementa IRequest<>");
-
-            var responseType = requestInterface.GetGenericArguments()[0];
-
-            return typeof(IRequestHandler<,>).MakeGenericType(type, responseType);
-        });
-    }
-
-    private static object GetHandler(IServiceProvider serviceProvider, Type handlerType)
-    {
-        return serviceProvider.GetRequiredService(handlerType);
-    }
-
-    private static Func<object, object, CancellationToken, Task<object>> GetHandlerDelegate(Type handlerType)
-    {
-        return _handlerDelegates.GetOrAdd(handlerType, type =>
-        {
-            //Encontrar a interface
-            var interfaceType = type.GetInterfaces()
-                                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequestHandler<,>))
-                                    ?? throw new InvalidOperationException($"Tipo {type} não implementa IRequestHandler");
-
-            var requestType = interfaceType.GetGenericArguments()[0];
-            var responseType = interfaceType.GetGenericArguments()[1];
-
-            var method = interfaceType.GetMethod("Handle");
-
-            var handlerParam = Expression.Parameter(typeof(object), "handler");
-            var requestParam = Expression.Parameter(typeof(object), "request");
-            var cancellationParam = Expression.Parameter(typeof(CancellationToken), "ct");
-
-            var handlerCast = Expression.Convert(handlerParam, type);
-            var requestCast = Expression.Convert(requestParam, requestType);
-
-            var call = Expression.Call(handlerCast, method, requestCast, cancellationParam);
-
-            //Auxilia na conversão de Task<T> em Task<object>
-            var wrapperMethod = typeof(Mediator)
-            .GetMethod(nameof(ConvertTaskToObjectAsync), BindingFlags.NonPublic | BindingFlags.Static)
-            .MakeGenericMethod(responseType);
-
-            var wrappedCall = Expression.Call(wrapperMethod, call);
-
-            return Expression.
-                    Lambda<Func<object, object, CancellationToken, Task<object>>>(
-                        wrappedCall,
-                        handlerParam,
-                        requestParam,
-                        cancellationParam)
-                    .Compile();
-        });
-    }
-
-    private static async Task<object> ConvertTaskToObjectAsync<T>(Task<T> task)
-    {
-        return await task.ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Envia uma requisição como objeto para o handler apropriado
-    /// Útil para chamadas via reflexão ou quando o tipo exato não é conhecido em tempo de compilação
-    /// </summary>
-    /// <param name="request">A requisição a ser processada como objeto</param>
-    /// <param name="cancellationToken">Token de cancelamento para operações assíncronas</param>
-    /// <returns>A resposta do handler como objeto</returns>
-    public async Task<object> Send(object request, CancellationToken cancellationToken = default)
-    {
-        if (request == null)
-            throw new ArgumentNullException(nameof(request));
-
-        var requestType = request.GetType();
-
-        try
-        {
-            // Encontrar o tipo de resposta apropriado
-            var responseType = GetResponseType(requestType);
-
-            // Criar o método genérico Send<TResponse>
-            var method = typeof(Mediator)
-                .GetMethods()
-                .First(m => m.Name == nameof(Send) && m.IsGenericMethod);
-
-            var genericMethod = method.MakeGenericMethod(responseType);
-
-            // Invocar o método genérico
-            return await (Task<object>)genericMethod.Invoke(this, new[] { request, cancellationToken });
-        }
-        catch (Exception ex)
-        {
-            // Preservar a stack trace original
-            ExceptionDispatchInfo.Capture(ex.InnerException ?? ex).Throw();
-            // Linha abaixo nunca é executada, apenas para compilação
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Obtém o tipo de resposta esperado para um tipo de requisição
-    /// </summary>
-    /// <param name="requestType">O tipo da requisição</param>
-    /// <returns>O tipo da resposta esperada</returns>
-    private Type GetResponseType(Type requestType)
-    {
-        // Encontrar a interface IRequest<TResponse> que o tipo implementa
-        var requestInterfaceType = requestType
-            .GetInterfaces()
-            .FirstOrDefault(i => i.IsGenericType &&
-                (i.GetGenericTypeDefinition() == typeof(IRequest<>) || i.GetGenericTypeDefinition() == typeof(IRequest)));
-
-        if (requestInterfaceType == null)
-        {
-            throw new InvalidOperationException($"O tipo {requestType.Name} não implementa IRequest<> ou IRequest");
-        }
-
-        // Se for IRequest, retorna Unit
-        if (requestInterfaceType.GetGenericTypeDefinition() == typeof(IRequest))
-        {
-            return typeof(Unit);
-        }
-
-        // Senão, retorna o tipo genérico da resposta
-        return requestInterfaceType.GetGenericArguments()[0];
     }
 }

--- a/src/Nuget/Handlers/Publisher.cs
+++ b/src/Nuget/Handlers/Publisher.cs
@@ -1,0 +1,65 @@
+﻿using MinDiator.Handlers.Base;
+using MinDiator.Interfaces;
+using System.Collections.Concurrent;
+
+namespace MinDiator.Handlers
+{
+    public class Publisher : IPublisher
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private static readonly ConcurrentDictionary<Type, NotificationHandlerBase> _notificationHandlers = new();
+
+        public Publisher(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+        {
+            if (notification == null)
+            {
+                throw new ArgumentNullException(nameof(notification));
+            }
+
+            var notificationType = notification.GetType();
+            var handler = _notificationHandlers.GetOrAdd(notificationType, type =>
+            {
+                var wrapperType = typeof(StaticCachedNotificationHandlerWrapper<>).MakeGenericType(type);
+
+                var wrapper = Activator.CreateInstance(wrapperType)
+                    ?? throw new InvalidOperationException($"Could not create notification wrapper type for {type}");
+
+                return (NotificationHandlerBase)wrapper;
+            });
+
+            return handler.Handle(notification, _serviceProvider, cancellationToken);
+        }
+
+        public Task Publish(INotification notification, CancellationToken cancellationToken = default)
+        {
+            if (notification == null)
+            {
+                throw new ArgumentNullException(nameof(notification));
+            }
+
+            var notificationType = notification.GetType();
+            var handler = _notificationHandlers.GetOrAdd(notificationType, type =>
+            {
+                if (!typeof(INotification).IsAssignableFrom(type))
+                {
+                    throw new InvalidOperationException($"Notification type {type.Name} does not implement INotification");
+                }
+
+                var wrapperType = typeof(StaticCachedNotificationHandlerWrapper<>).MakeGenericType(type);
+
+                var wrapper = Activator.CreateInstance(wrapperType)
+                    ?? throw new InvalidOperationException($"Could not create notification wrapper type for {type}");
+
+                return (NotificationHandlerBase)wrapper;
+            });
+
+            return handler.Handle(notification, _serviceProvider, cancellationToken);
+        }
+    }
+}

--- a/src/Nuget/Handlers/RequestHandlerDelegate.cs
+++ b/src/Nuget/Handlers/RequestHandlerDelegate.cs
@@ -1,7 +1,8 @@
 ﻿namespace MinDiator.Handlers;
 /// <summary>
-/// Delegate que encapsula a chamada para o próximo handler ou behavior na cadeia
+/// Delegate that encapsulates the call to the next handler or behavior in the chain
 /// </summary>
-/// <typeparam name="TResponse">Tipo de resposta esperada</returns>
-/// <returns>Task contendo a resposta</returns>
-public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+/// <typeparam name="TResponse">Expected response type</returns>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>Task containing the response</returns>
+public delegate Task<TResponse> RequestHandlerDelegate<TResponse>(CancellationToken cancellationToken = default);

--- a/src/Nuget/Interfaces/INotification.cs
+++ b/src/Nuget/Interfaces/INotification.cs
@@ -1,0 +1,9 @@
+﻿namespace MinDiator.Interfaces
+{
+    /// <summary>
+    /// Marker interface to represent a notification
+    /// </summary>
+    public interface INotification
+    {
+    }
+}

--- a/src/Nuget/Interfaces/INotificationHandler.cs
+++ b/src/Nuget/Interfaces/INotificationHandler.cs
@@ -1,0 +1,17 @@
+﻿namespace MinDiator.Interfaces
+{
+    /// <summary>
+    /// Defines a handler for a notification
+    /// </summary>
+    /// <typeparam name="TNotification">The notification type</typeparam>
+    public interface INotificationHandler<in TNotification> where TNotification : INotification
+    {
+        /// <summary>
+        /// Handles a notification
+        /// </summary>
+        /// <param name="notification">The notification</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the notification handling</returns>
+        Task Handle(TNotification notification, CancellationToken cancellationToken);
+    }
+}

--- a/src/Nuget/Interfaces/IPublisher.cs
+++ b/src/Nuget/Interfaces/IPublisher.cs
@@ -1,0 +1,26 @@
+﻿namespace MinDiator.Interfaces
+{
+    /// <summary>
+    /// Defines a publisher interface for notifications
+    /// </summary>
+    public interface IPublisher
+    {
+        /// <summary>
+        /// Publishes a notification to multiple handlers
+        /// </summary>
+        /// <param name="notification">The notification to be published</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>A task representing the publication process</returns>
+        Task Publish(INotification notification, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Publishes a notification to multiple handlers
+        /// </summary>
+        /// <typeparam name="TNotification">The notification type</typeparam>
+        /// <param name="notification">The notification to be published</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>A task representing the publication process</returns>
+        Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification;
+    }
+}

--- a/src/Nuget/MinDiator.csproj
+++ b/src/Nuget/MinDiator.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />    
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Adding MediatR core features to the package

The following features and refactors have been applied:

- Added MediatR core features such as `IPublisher` and `INotification`.
- Introduced the same technique used by MediatR to reduce reflection usage — based on wrapper classes for handlers and behaviors, which cache instantiation methods.
- Added unit tests for core features (`Mediator`, `Publisher`, and `Sender`).
- Fixed benchmarks for a fair comparison. The previous version used different reflection logic in `MediatRPerformanceBehavior`, which led to incorrect interpretations of the results.
- Removed `IExceptionHandler` handling logic from the `Mediator` class. This is a **breaking change**, but neither our code referenced this interface nor did the `README.md` show any examples of its usage. It’s a great feature, but I wasn’t able to make it work before running out of free time ⏰. I left a TODO for it (sorry about that).

## Performance considerations

The current version of the package underperforms MediatR in terms of execution time for handlers.  
`Publisher` and `Sender` are even slower, but the difference is negligible for 99.99% of applications.

![image](https://github.com/user-attachments/assets/0727153f-c739-4c25-8a05-4aecbfc58f88)

If ~200ns is a critical performance factor for your application, you should probably avoid any Mediator implementation that relies on reflection, IMHO.  
On the bright side, we're slightly outperforming MediatR in terms of **memory allocation**.